### PR TITLE
Added infinite retry to service

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,6 +2,11 @@
   {{title}}
 </h1>
 
+<button (click)="toggleConnection()">Toggle connection</button>
+<div *ngIf="connection">We have connection!</div>
+
+<br>
+
 <button (click)="add()">ADD</button>
 <br>
 <b>Stuff from firebase:</b>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,23 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
+import { NetworkService } from './network-service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'app works!';
 
   stuffFromFirebase: Observable<any[]>;
 
-  constructor(private store: Store<any>) {
+  connection;
+
+  constructor(
+    private store: Store<any>,
+    private networkService: NetworkService
+  ) {
     this.stuffFromFirebase = this.store.select('state')
       .map(state => state);
   }
 
   add() {
     this.store.dispatch({type: 'ADD', payload: ''});
+  }
+
+  toggleConnection() {
+    this.networkService.toggleConnection();
+    this.refreshConnectionState();
+  }
+
+  ngOnInit() {
+    this.refreshConnectionState();
+  }
+
+  refreshConnectionState() {
+    this.connection = this.networkService.hasConnection();
   }
 }

--- a/src/app/network-service.ts
+++ b/src/app/network-service.ts
@@ -7,4 +7,8 @@ export class NetworkService {
   hasConnection(): boolean {
     return this.connection;
   }
+
+  toggleConnection() {
+    this.connection = !this.connection;
+  }
 }

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -3,9 +3,10 @@ import { Action } from '@ngrx/store';
 export function reducer(state = [], action: Action)  {
   switch (action.type) {
     case 'ADD':
-      return state;
-    case 'ADDED':
       return [ ...state, action.payload ];
+    case 'ADDED':
+      console.log('Now stuff has been added to firebase');
+      return state;
     case 'ACTION_ERROR':
       return state;
     default:

--- a/src/app/service.ts
+++ b/src/app/service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/interval';
 import 'rxjs/add/operator/do';
-import 'rxjs/add/observable/range';
 import 'rxjs/add/operator/delay';
+import 'rxjs/add/operator/retryWhen';
 import { NetworkService } from './network-service';
 
 @Injectable()
@@ -13,13 +12,16 @@ export class Service {
   constructor(private networkService: NetworkService) {}
 
   addFeed(action: any): Observable<any> {
-    if (this.networkService.hasConnection()) {
-      return Observable.of('Some stuff from firebase')
-        .do(() => console.log('doing whatever addFeed does'));
-    } else {
-      return Observable.of('Some stuff from firebase')
-        .delay(3000) // ms
-        .do(() => console.log('doing whatever addFeed does, but 3 seconds later'));
-    }
+    return Observable.of('Stuff from firebase')
+      .map(stuff => {
+        if (!this.networkService.hasConnection()) {
+          throw Error('No connection');
+        }
+        console.log('We have a connection!');
+        return stuff;
+      })
+      .retryWhen(errors => errors
+        .do(() => console.log('Waiting for connection'))
+        .delay(3000));
   }
 }


### PR DESCRIPTION
@krz37 if you want to wait for 3 seconds and retry indefinitely, or until you get a connection, the reactive way would be something like this.

The ADD reducer will add to the state and the effect goes off in the background to do whatever spiderpig does.

I added a toggle connection button so you can fire off the add, follow the log and then toggle the connection again. I hope this shows clearly how this works.
